### PR TITLE
Specify open encoding

### DIFF
--- a/JGLUE.py
+++ b/JGLUE.py
@@ -580,7 +580,7 @@ class JGLUE(ds.GeneratorBasedBuilder):
         if file_path is None:
             raise ValueError(f"Invalid argument for {self.config.name}")
 
-        with open(file_path, "r") as rf:
+        with open(file_path, "r", encoding="utf-8") as rf:
             for i, line in enumerate(rf):
                 json_dict = json.loads(line)
                 json_dict["label"] = f"choice{json_dict['label']}"
@@ -590,7 +590,7 @@ class JGLUE(ds.GeneratorBasedBuilder):
         if file_path is None:
             raise ValueError(f"Invalid argument for {self.config.name}")
 
-        with open(file_path, "r") as rf:
+        with open(file_path, "r", encoding="utf-8") as rf:
             for i, line in enumerate(rf):
                 json_dict = json.loads(line)
                 yield i, json_dict


### PR DESCRIPTION
This adds the file encoding to two `open` calls. 

For some reason, in one particular cluster environment I use, not doing this causes errors because the files are opened in `ascii` mode. The environment should be completely UTF-8 so not sure why it's happening, but this modification fixes it and shouldn't cause issues even in environments where it's not strictly necessary.