### PR TITLE
Remove datasets.tasks and add trust_remote_code

### DIFF
--- a/JGLUE.py
+++ b/JGLUE.py
@@ -8,7 +8,6 @@ from typing import Dict, List, Literal, Optional
 
 import datasets as ds
 import pandas as pd
-from datasets.tasks import QuestionAnsweringExtractive
 
 logger = logging.getLogger(__name__)
 
@@ -201,13 +200,6 @@ def dataset_info_jsquad() -> ds.DatasetInfo:
         license=_JGLUE_LICENSE,
         features=features,
         supervised_keys=None,
-        task_templates=[
-            QuestionAnsweringExtractive(
-                question_column="question",
-                context_column="context",
-                answers_column="answers",
-            )
-        ],
     )
 
 

--- a/JGLUE.py
+++ b/JGLUE.py
@@ -584,7 +584,12 @@ class JGLUE(ds.GeneratorBasedBuilder):
             raise ValueError(f"Invalid config name: {self.config.name}")
 
     def __split_generators_marc_ja(self, dl_manager: ds.DownloadManager):
-        file_paths = dl_manager.download_and_extract(_URLS[self.config.name])
+        try:
+            file_paths = dl_manager.download_and_extract(_URLS[self.config.name])
+        except FileNotFoundError as err:
+            logger.warning(err)
+            _URLS[self.config.name].pop("data")
+            file_paths = dl_manager.download_and_extract(_URLS[self.config.name])
 
         filter_review_id_list = file_paths["filter_review_id_list"]
         label_conv_review_id_list = file_paths["label_conv_review_id_list"]

--- a/JGLUE.py
+++ b/JGLUE.py
@@ -588,8 +588,9 @@ class JGLUE(ds.GeneratorBasedBuilder):
             file_paths = dl_manager.download_and_extract(_URLS[self.config.name])
         except FileNotFoundError as err:
             logger.warning(err)
-            _URLS[self.config.name].pop("data")
-            file_paths = dl_manager.download_and_extract(_URLS[self.config.name])
+            urls = _URLS[self.config.name]
+            urls.pop("data")  # type: ignore[attr-defined]
+            file_paths = dl_manager.download_and_extract(urls)
 
         filter_review_id_list = file_paths["filter_review_id_list"]
         label_conv_review_id_list = file_paths["label_conv_review_id_list"]

--- a/JGLUE.py
+++ b/JGLUE.py
@@ -588,6 +588,8 @@ class JGLUE(ds.GeneratorBasedBuilder):
             file_paths = dl_manager.download_and_extract(_URLS[self.config.name])
         except FileNotFoundError as err:
             logger.warning(err)
+            # An error occurs because the file cannot be downloaded from _URLS[MARC-ja]['data'].
+            # So, remove the 'data' key and try to download again.
             urls = _URLS[self.config.name]
             urls.pop("data")  # type: ignore[attr-defined]
             file_paths = dl_manager.download_and_extract(urls)

--- a/tests/JGLUE_test.py
+++ b/tests/JGLUE_test.py
@@ -22,7 +22,7 @@ def test_load_dataset(
     expected_num_train: int,
     expected_num_valid: int,
 ):
-    dataset = ds.load_dataset(path=dataset_path, name=dataset_name)
+    dataset = ds.load_dataset(path=dataset_path, name=dataset_name, trust_remote_code=True)
 
     assert dataset["train"].num_rows == expected_num_train
     assert dataset["validation"].num_rows == expected_num_valid
@@ -41,6 +41,7 @@ def test_load_marc_ja(
         max_char_length=500,
         filter_review_id_list_valid=True,
         label_conv_review_id_list_valid=True,
+        trust_remote_code=True,
     )
 
     assert dataset["train"].num_rows == expected_num_train
@@ -54,7 +55,7 @@ def test_load_jcola(
     expected_num_valid: int = 865,
     expected_num_valid_ood: int = 685,
 ):
-    dataset = ds.load_dataset(path=dataset_path, name=dataset_name)
+    dataset = ds.load_dataset(path=dataset_path, name=dataset_name, trust_remote_code=True)
     assert dataset["train"].num_rows == expected_num_train
     assert dataset["validation"].num_rows == expected_num_valid
     assert dataset["validation_out_of_domain"].num_rows == expected_num_valid_ood

--- a/tests/JGLUE_test.py
+++ b/tests/JGLUE_test.py
@@ -1,6 +1,8 @@
 import datasets as ds
 import pytest
 
+ds.config.HF_DATASETS_TRUST_REMOTE_CODE = True
+
 
 @pytest.fixture
 def dataset_path() -> str:
@@ -22,7 +24,7 @@ def test_load_dataset(
     expected_num_train: int,
     expected_num_valid: int,
 ):
-    dataset = ds.load_dataset(path=dataset_path, name=dataset_name, trust_remote_code=True)
+    dataset = ds.load_dataset(path=dataset_path, name=dataset_name)
 
     assert dataset["train"].num_rows == expected_num_train
     assert dataset["validation"].num_rows == expected_num_valid
@@ -41,7 +43,6 @@ def test_load_marc_ja(
         max_char_length=500,
         filter_review_id_list_valid=True,
         label_conv_review_id_list_valid=True,
-        trust_remote_code=True,
     )
 
     assert dataset["train"].num_rows == expected_num_train
@@ -55,7 +56,7 @@ def test_load_jcola(
     expected_num_valid: int = 865,
     expected_num_valid_ood: int = 685,
 ):
-    dataset = ds.load_dataset(path=dataset_path, name=dataset_name, trust_remote_code=True)
+    dataset = ds.load_dataset(path=dataset_path, name=dataset_name)
     assert dataset["train"].num_rows == expected_num_train
     assert dataset["validation"].num_rows == expected_num_valid
     assert dataset["validation_out_of_domain"].num_rows == expected_num_valid_ood

--- a/tests/JGLUE_test.py
+++ b/tests/JGLUE_test.py
@@ -1,6 +1,9 @@
 import datasets as ds
 import pytest
 
+# In datasets>=3.0.0, HF_DATASETS_TRUST_REMOTE_CODE defaults to False,
+# which triggers confirmation dialogs when loading datasets and interrupts testing.
+# Therefore, HF_DATASETS_TRUST_REMOTE_CODE is set to True.
 ds.config.HF_DATASETS_TRUST_REMOTE_CODE = True
 
 


### PR DESCRIPTION
According to https://github.com/huggingface/datasets/pull/6999, `datasets.task` has been removed in Huggingface datasets >= 3.0.0.
In addition, `trust_remote_code` is added to prevent dialogue with test code.

Regarding the above fix, I tested the code using pytest with datasets v2.21.0 and v3.0.0. However, in v3.0.0, an error occurred in the following part of downloading MARC-ja.

Before:

https://github.com/shunk031/huggingface-datasets_JGLUE/blob/db29e61a4b08381f841212b550e8bc08cdeb372a/JGLUE.py#L595

Fixed:

```python
    def __split_generators_marc_ja(self, dl_manager: ds.DownloadManager):
        try:
            file_paths = dl_manager.download_and_extract(_URLS[self.config.name])
        except FileNotFoundError as err:
            logger.warning(err)
            _URLS[self.config.name].pop("data")
            file_paths = dl_manager.download_and_extract(_URLS[self.config.name])
```

I've added new error handling since the errors occur at different points in the two versions. 
The modifications have been made to respect the original code and other issues, but it might be better to delete the `"data"` URL in MARC-ja.